### PR TITLE
Read GOOGLE_CREDENTIALS during startup, not app compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,5 +7,5 @@ ENV_DIR=${3:-}
 
 echo "------> Generating .profile.d file to generate google-credentials.json at startup"
 mkdir -p $BUILD_DIR/.profile.d
-echo "echo ${GOOGLE_CREDENTIALS@Q} > /app/google-credentials.json" > $BUILD_DIR/.profile.d/google-credentials.sh
+echo "echo \${GOOGLE_CREDENTIALS} > /app/google-credentials.json" > $BUILD_DIR/.profile.d/google-credentials.sh
 chmod +x $BUILD_DIR/.profile.d/google-credentials.sh


### PR DESCRIPTION
This pull request escapes the reference to the GOOGLE_CREDENTIALS environment variable when creating the `$BUILD_DIR/.profile.d/google-credentials.sh` script, so the script ends up containing:

```
echo ${GOOGLE_CREDENTIALS} > /app/google-credentials.json
```

This variable is then read during startup when the profile.d script runs and its current contents written to `/app/google-credentials.json`. (Prior to this change it was being read during compilation, and not with the suggested approach of going via $ENV_DIR).

Tested against `heroku-18` stack.